### PR TITLE
Remove the return

### DIFF
--- a/unanet-summarizer.js
+++ b/unanet-summarizer.js
@@ -12,8 +12,4 @@ window.summarizeUnanetTime = (function() {
         s.onload = onload;
         document.body.appendChild(s);
     }
-
-    return function() {
-        onload();
-    };
 })();


### PR DESCRIPTION
Resolves #36.

At the time the return fires, the script is not yet loaded and so we we see the error. Since the script also has an onload event handler, we're covered if we remove this.