### PR TITLE
Stop using dist

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,5 +23,5 @@ steps:
 - task: PublishPipelineArtifact@0
   displayName: Publish Pipeline Artifacts
   inputs:
-    targetPath: $(Build.ArtifactStagingDirectory)/dist
+    targetPath: '$(Build.ArtifactStagingDirectory)'
   condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')


### PR DESCRIPTION
Supports #49 and #32. 

I think Azure pipelines may automatically output the dist folder to the Staging artifacts directory. That would be very interesting if it did that automatically. We'll see; this tests. it.