### PR TITLE
Fix Alex timesheet tracking issue

### DIFF
--- a/src/classes/Loaders/EditModeLoader.ts
+++ b/src/classes/Loaders/EditModeLoader.ts
@@ -14,7 +14,7 @@ export class EditModeLoader implements ITimesheetLoader {
 
   constructor(pageTitle: string, timesheetTable: Element) {
     this.pageTitle = pageTitle;
-    this.todayDate = moment();
+    this.todayDate = moment().startOf("day");
     this.timesheetTable = timesheetTable;
     this.parseTimesheetDateStrings(this.pageTitle);
   }

--- a/src/classes/Loaders/ReviewModeLoader.ts
+++ b/src/classes/Loaders/ReviewModeLoader.ts
@@ -14,7 +14,7 @@ export class ReviewModeLoader implements ITimesheetLoader {
 
   constructor(pageTitle: string, timesheetTable: Element) {
     this.pageTitle = pageTitle;
-    this.todayDate = moment();
+    this.todayDate = moment().startOf("day");
     this.timesheetTable = timesheetTable;
   }
 

--- a/src/classes/Timesheet.ts
+++ b/src/classes/Timesheet.ts
@@ -66,7 +66,6 @@ export class Timesheet {
     const remainingWorkingDays: number = this.numberOfRemainingWorkDays();
     const expectedHours: number = workingDays * this.HOURS_IN_WORKDAY;
     const actualHours: number = this.totalPlusHours() + remainingWorkingDays * this.HOURS_IN_WORKDAY;
-
     return actualHours - expectedHours;
   };
 

--- a/src/classes/Timesheet.ts
+++ b/src/classes/Timesheet.ts
@@ -63,9 +63,13 @@ export class Timesheet {
 
   public plusHoursTracking = (): number => {
     const workingDays: number = this.weekdaysInTimesheet();
+    console.log("workingDays", workingDays);
     const remainingWorkingDays: number = this.numberOfRemainingWorkDays();
+    console.log("remainingWorkingDays", remainingWorkingDays);
     const expectedHours: number = workingDays * this.HOURS_IN_WORKDAY;
+    console.log("expectedHours", expectedHours);
     const actualHours: number = this.totalPlusHours() + remainingWorkingDays * this.HOURS_IN_WORKDAY;
+    console.log("actualHours", actualHours);
 
     return actualHours - expectedHours;
   };

--- a/src/classes/Timesheet.ts
+++ b/src/classes/Timesheet.ts
@@ -63,13 +63,9 @@ export class Timesheet {
 
   public plusHoursTracking = (): number => {
     const workingDays: number = this.weekdaysInTimesheet();
-    console.log("workingDays", workingDays);
     const remainingWorkingDays: number = this.numberOfRemainingWorkDays();
-    console.log("remainingWorkingDays", remainingWorkingDays);
     const expectedHours: number = workingDays * this.HOURS_IN_WORKDAY;
-    console.log("expectedHours", expectedHours);
     const actualHours: number = this.totalPlusHours() + remainingWorkingDays * this.HOURS_IN_WORKDAY;
-    console.log("actualHours", actualHours);
 
     return actualHours - expectedHours;
   };

--- a/src/classes/Timesheet.ts
+++ b/src/classes/Timesheet.ts
@@ -123,7 +123,7 @@ export class Timesheet {
 
   private weekDaysBetweenDates = (theStartDate: moment.Moment, endDate: moment.Moment): number => {
     let totalWeekDays: number = 0;
-    const startDate: moment.Moment = theStartDate.clone();
+    const startDate: moment.Moment = theStartDate.clone().startOf("day");
     while (startDate <= endDate) {
       if (this.isWeekday(startDate)) {
         totalWeekDays++; // add 1 to your counter if its not a weekend day
@@ -162,7 +162,7 @@ export class Timesheet {
       throw new Error(`${type} is invalid.`);
     }
 
-    const date: moment.Moment = moment(timesheetStartDate);
+    const date: moment.Moment = moment(timesheetStartDate).startOf("day");
 
     if (!date.isValid()) {
       throw new Error(`${type} is invalid.`);

--- a/src/classes/Timesheet.ts
+++ b/src/classes/Timesheet.ts
@@ -121,9 +121,10 @@ export class Timesheet {
     return formattedDate !== "sat" && formattedDate !== "sun";
   };
 
-  private weekDaysBetweenDates = (theStartDate: moment.Moment, endDate: moment.Moment): number => {
+  private weekDaysBetweenDates = (theStartDate: moment.Moment, theEndDate: moment.Moment): number => {
     let totalWeekDays: number = 0;
     const startDate: moment.Moment = theStartDate.clone().startOf("day");
+    const endDate: moment.Moment = theEndDate.clone().startOf("day");
     while (startDate <= endDate) {
       if (this.isWeekday(startDate)) {
         totalWeekDays++; // add 1 to your counter if its not a weekend day

--- a/src/classes/Timesheet.ts
+++ b/src/classes/Timesheet.ts
@@ -95,6 +95,9 @@ export class Timesheet {
 
   public numberOfRemainingWorkDays = (): number => {
     let workingDaysLeft: number = this.weekDaysBetweenDates(this.todaysDate, this.timesheetEndDate);
+    if (workingDaysLeft === 0) {
+      return 0;
+    }
     if (this.hoursForDate(this.todaysDate.date()) > 0 && this.isWeekday(this.todaysDate)) {
       workingDaysLeft--;
     }

--- a/tests/Loaders/EditModeLoaderTest.ts
+++ b/tests/Loaders/EditModeLoaderTest.ts
@@ -26,7 +26,7 @@ describe("timesheet loader", () => {
       const loader = new EditModeLoader(pageTitle, timesheetTable);
       const timesheet = loader.getTimesheet();
 
-      const expectedStartDate = moment("2019-09-16");
+      const expectedStartDate = moment("2019-09-16").startOf("day");
       expect(expectedStartDate.isSame(timesheet.timesheetStartDate)).toBe(true);
     });
 
@@ -34,7 +34,7 @@ describe("timesheet loader", () => {
       const loader = new EditModeLoader(pageTitle, timesheetTable);
       const timesheet = loader.getTimesheet();
 
-      const expectedEndDate = moment("2019-09-30");
+      const expectedEndDate = moment("2019-09-30").startOf("day");
       expect(expectedEndDate.isSame(timesheet.timesheetEndDate)).toBe(true);
     });
 
@@ -42,7 +42,7 @@ describe("timesheet loader", () => {
       const loader = new EditModeLoader(pageTitle, timesheetTable);
       const timesheet = loader.getTimesheet();
 
-      const expectedTodayDate = moment();
+      const expectedTodayDate = moment().startOf("day");
       expect(expectedTodayDate.isSame(timesheet.todaysDate, "date")).toBe(true);
     });
 

--- a/tests/Loaders/ReviewModeLoaderTest.ts
+++ b/tests/Loaders/ReviewModeLoaderTest.ts
@@ -26,7 +26,7 @@ describe("timesheet loader", () => {
       const loader = new ReviewModeLoader(pageTitle, timesheetTable);
       const timesheet = loader.getTimesheet();
 
-      const expectedStartDate = moment("2019-09-01");
+      const expectedStartDate = moment("2019-09-01").startOf("day");
       expect(expectedStartDate.isSame(timesheet.timesheetStartDate)).toBe(true);
     });
 
@@ -34,7 +34,7 @@ describe("timesheet loader", () => {
       const loader = new ReviewModeLoader(pageTitle, timesheetTable);
       const timesheet = loader.getTimesheet();
 
-      const expectedEndDate = moment("2019-09-15");
+      const expectedEndDate = moment("2019-09-15").startOf("day");
       expect(expectedEndDate.isSame(timesheet.timesheetEndDate)).toBe(true);
     });
 
@@ -42,7 +42,7 @@ describe("timesheet loader", () => {
       const loader = new ReviewModeLoader(pageTitle, timesheetTable);
       const timesheet = loader.getTimesheet();
 
-      const expectedTodayDate = moment();
+      const expectedTodayDate = moment().startOf("day");
       expect(expectedTodayDate.isSame(timesheet.todaysDate, "date")).toBe(true);
     });
 

--- a/tests/TimesheetTest.ts
+++ b/tests/TimesheetTest.ts
@@ -967,5 +967,11 @@ describe("timesheet", () => {
 
       expect(nonPlus).toBe(66.75);
     });
+
+    it("tracks total correctly", () => {
+      const totalHours = timesheet.totalNonPlusHours() + timesheet.totalPlusHours();
+
+      expect(totalHours).toBe(146.75);
+    });
   });
 });

--- a/tests/TimesheetTest.ts
+++ b/tests/TimesheetTest.ts
@@ -695,8 +695,20 @@ describe("timesheet", () => {
 
       expect(timesheet.numberOfRemainingWorkDays()).toBe(0);
     });
+    it("returns zero when today is the first of the month after the timesheet end even when there are hours on the last day", () => {
+      const timeOnLastDay: TimesheetRow[] = new TimesheetRowArrayBuilder().plusHoursForDates([15]);
+      const timesheet: Timesheet = new Timesheet(timeOnLastDay, startDate, endDate, "2019-10-01");
+
+      expect(timesheet.numberOfRemainingWorkDays()).toBe(0);
+    });
+    it("returns zero when today is the first of the month after the timesheet end even when there are non-plus hours on the last day", () => {
+      const timeOnLastDay: TimesheetRow[] = new TimesheetRowArrayBuilder().nonPlusHoursForDates([15]);
+      const timesheet: Timesheet = new Timesheet(timeOnLastDay, startDate, endDate, "2019-10-01");
+
+      expect(timesheet.numberOfRemainingWorkDays()).toBe(0);
+    });
     it("returns zero when today is a month after the timesheet end", () => {
-      const timesheet: Timesheet = new Timesheet(rowsThatDontMatter, startDate, endDate, "2019-10-27");
+      const timesheet: Timesheet = new Timesheet(rowsThatDontMatter, startDate, endDate, "2019-10-30");
 
       expect(timesheet.numberOfRemainingWorkDays()).toBe(0);
     });

--- a/tests/TimesheetTest.ts
+++ b/tests/TimesheetTest.ts
@@ -946,15 +946,15 @@ describe("timesheet", () => {
       expect(billable).toBe(16);
     });
     it("tracks core hours correctly", () => {
-      const billable = timesheet.hoursByProjectType().find(x => x.projectType === ProjectType.Core).total;
+      const coreHours = timesheet.hoursByProjectType().find(x => x.projectType === ProjectType.Core).total;
 
-      expect(billable).toBe(64);
+      expect(coreHours).toBe(64);
     });
 
     it("tracks int hours correctly", () => {
-      const billable = timesheet.hoursByProjectType().find(x => x.projectType === ProjectType.Internal).total;
+      const intHours = timesheet.hoursByProjectType().find(x => x.projectType === ProjectType.Internal).total;
 
-      expect(billable).toBe(66.75);
+      expect(intHours).toBe(66.75);
     });
 
     it("tracks total plus correctly", () => {
@@ -963,9 +963,9 @@ describe("timesheet", () => {
       expect(plusHours).toBe(80);
     });
     it("tracks non-plus correctly", () => {
-      const plusHours = timesheet.totalPlusHours();
+      const nonPlus = timesheet.totalNonPlusHours();
 
-      expect(plusHours).toBe(66.75);
+      expect(nonPlus).toBe(66.75);
     });
   });
 });

--- a/tests/TimesheetTest.ts
+++ b/tests/TimesheetTest.ts
@@ -968,7 +968,7 @@ describe("timesheet", () => {
 
     rows = rows.concat(nrecaRow, holidayRow, solutionRow, demoRow, eventsRow, eventsRow2, eventsRow3);
 
-    const timesheet = new Timesheet(rows, "2019-09-01", "2019-09-05", "2019-10-01");
+    const timesheet = new Timesheet(rows, "2019-09-01", "2019-09-15", "2019-10-01");
 
     it("tracks billable hours correctly", () => {
       const billable = timesheet.hoursByProjectType().find(x => x.projectType === ProjectType.Bill).total;

--- a/tests/TimesheetTest.ts
+++ b/tests/TimesheetTest.ts
@@ -690,6 +690,16 @@ describe("timesheet", () => {
 
       expect(timesheet.numberOfRemainingWorkDays()).toBe(0);
     });
+    it("returns zero when today is the first of the month after the timesheet end", () => {
+      const timesheet: Timesheet = new Timesheet(rowsThatDontMatter, startDate, endDate, "2019-10-01");
+
+      expect(timesheet.numberOfRemainingWorkDays()).toBe(0);
+    });
+    it("returns zero when today is a month after the timesheet end", () => {
+      const timesheet: Timesheet = new Timesheet(rowsThatDontMatter, startDate, endDate, "2019-10-27");
+
+      expect(timesheet.numberOfRemainingWorkDays()).toBe(0);
+    });
     it("returns zero when today is in a weekend at the end of the timesheet", () => {
       const timesheet: Timesheet = new Timesheet(rowsThatDontMatter, startDate, endDate, "2019-09-14");
 
@@ -979,6 +989,7 @@ describe("timesheet", () => {
 
       expect(totalHours).toBe(146.75);
     });
+
     it("has correct tracking amount", () => {
       const tracking = timesheet.plusHoursTracking();
 

--- a/tests/TimesheetTest.ts
+++ b/tests/TimesheetTest.ts
@@ -945,5 +945,10 @@ describe("timesheet", () => {
 
       expect(billable).toBe(16);
     });
+    it("tracks core hours correctly", () => {
+      const billable = timesheet.hoursByProjectType().find(x => x.projectType === ProjectType.Core).total;
+
+      expect(billable).toBe(64);
+    });
   });
 });

--- a/tests/TimesheetTest.ts
+++ b/tests/TimesheetTest.ts
@@ -877,4 +877,73 @@ describe("timesheet", () => {
       expect(timesheet.hoursByProjectType().find(i => i.projectType === ProjectType.Core).total).toBe(46.75);
     });
   });
+
+  describe("Alex's timesheet issue", () => {
+    let rows: TimesheetRow[] = new Array<TimesheetRow>();
+
+    const nrecaRow: TimesheetRow = new TimesheetRowBuilder()
+      .withProjectType(ProjectType.Bill)
+      .withEntry(new DateEntry("3", "8.50"))
+      .withEntry(new DateEntry("4", "7.50"))
+      .build();
+
+    const holidayRow: TimesheetRow = new TimesheetRowBuilder()
+      .withProjectType(ProjectType.Core)
+      .withEntry(new DateEntry("2", "8"))
+      .build();
+
+    const solutionRow: TimesheetRow = new TimesheetRowBuilder()
+      .withProjectType(ProjectType.Internal)
+      .withEntry(new DateEntry("3", ".75"))
+      .build();
+
+    const demoRow: TimesheetRow = new TimesheetRowBuilder()
+      .withProjectType(ProjectType.Internal)
+      .withEntry(new DateEntry("1", "3"))
+      .withEntry(new DateEntry("2", "8"))
+      .withEntry(new DateEntry("3", "2"))
+      .withEntry(new DateEntry("4", "2"))
+      .withEntry(new DateEntry("5", "3"))
+      .withEntry(new DateEntry("6", "2"))
+      .withEntry(new DateEntry("7", "0"))
+      .withEntry(new DateEntry("8", "3"))
+      .withEntry(new DateEntry("11", "2"))
+      .withEntry(new DateEntry("13", "0"))
+      .withEntry(new DateEntry("15", "1"))
+      .build();
+
+    const eventsRow: TimesheetRow = new TimesheetRowBuilder()
+      .withProjectType(ProjectType.Core)
+      .withEntry(new DateEntry("5", "8"))
+      .withEntry(new DateEntry("6", "8"))
+      .withEntry(new DateEntry("10", "8"))
+      .withEntry(new DateEntry("11", "8"))
+      .withEntry(new DateEntry("12", "8"))
+      .withEntry(new DateEntry("13", "8"))
+      .build();
+
+    const eventsRow2: TimesheetRow = new TimesheetRowBuilder()
+      .withProjectType(ProjectType.Internal)
+      .withEntry(new DateEntry("4", "4"))
+      .withEntry(new DateEntry("7", "8"))
+      .withEntry(new DateEntry("8", "5"))
+      .withEntry(new DateEntry("9", "10"))
+      .withEntry(new DateEntry("14", "13"))
+      .build();
+
+    const eventsRow3: TimesheetRow = new TimesheetRowBuilder()
+      .withProjectType(ProjectType.Core)
+      .withEntry(new DateEntry("9", "8"))
+      .build();
+
+    rows = rows.concat(nrecaRow, holidayRow, solutionRow, demoRow, eventsRow, eventsRow2, eventsRow3);
+
+    const timesheet = new Timesheet(rows, "2019-09-01", "2019-09-05", "2019-10-01");
+
+    it("tracks billable hours correctly", () => {
+      const billable = timesheet.hoursByProjectType().find(x => x.projectType === ProjectType.Bill).total;
+
+      expect(billable).toBe(16);
+    });
+  });
 });

--- a/tests/TimesheetTest.ts
+++ b/tests/TimesheetTest.ts
@@ -950,10 +950,22 @@ describe("timesheet", () => {
 
       expect(billable).toBe(64);
     });
+
     it("tracks int hours correctly", () => {
       const billable = timesheet.hoursByProjectType().find(x => x.projectType === ProjectType.Internal).total;
 
       expect(billable).toBe(66.75);
+    });
+
+    it("tracks total plus correctly", () => {
+      const plusHours = timesheet.totalPlusHours();
+
+      expect(plusHours).toBe(80);
+    });
+    it("tracks non-plus correctly", () => {
+      const plusHours = timesheet.totalPlusHours();
+
+      expect(plusHours).toBe(66.75);
     });
   });
 });

--- a/tests/TimesheetTest.ts
+++ b/tests/TimesheetTest.ts
@@ -1003,5 +1003,8 @@ describe("timesheet", () => {
 
       expect(tracking).toBe(0);
     });
+    it("has the correct working days", () => {
+      expect(timesheet.numberOfRemainingWorkDays()).toBe(0);
+    });
   });
 });

--- a/tests/TimesheetTest.ts
+++ b/tests/TimesheetTest.ts
@@ -950,5 +950,10 @@ describe("timesheet", () => {
 
       expect(billable).toBe(64);
     });
+    it("tracks int hours correctly", () => {
+      const billable = timesheet.hoursByProjectType().find(x => x.projectType === ProjectType.Internal).total;
+
+      expect(billable).toBe(66.75);
+    });
   });
 });

--- a/tests/TimesheetTest.ts
+++ b/tests/TimesheetTest.ts
@@ -757,6 +757,14 @@ describe("timesheet", () => {
 
         expect(timesheet.weekdaysInTimesheet()).toBe(10);
       });
+      it("returns the correct number of weekdays in the 9/1/19 - 9/15/19 pay period on 10/1", () => {
+        const rowArrayThatDoesntMatter: TimesheetRow[] = new TimesheetRowArrayBuilder().plusHoursForDates([8]);
+        const octoberFirst: string = "2019-10-01";
+
+        const timesheet: Timesheet = new Timesheet(rowArrayThatDoesntMatter, "2019-09-01", "2019-09-15", octoberFirst);
+
+        expect(timesheet.weekdaysInTimesheet()).toBe(10);
+      });
     });
   });
   describe("hoursByProjectType", () => {

--- a/tests/TimesheetTest.ts
+++ b/tests/TimesheetTest.ts
@@ -957,6 +957,12 @@ describe("timesheet", () => {
       expect(intHours).toBe(66.75);
     });
 
+    it("tracks bench hours correctly", () => {
+      const bench = timesheet.hoursByProjectType().find(x => x.projectType === ProjectType.Bench).total;
+
+      expect(bench).toBe(0);
+    });
+
     it("tracks total plus correctly", () => {
       const plusHours = timesheet.totalPlusHours();
 
@@ -972,6 +978,11 @@ describe("timesheet", () => {
       const totalHours = timesheet.totalNonPlusHours() + timesheet.totalPlusHours();
 
       expect(totalHours).toBe(146.75);
+    });
+    it("has correct tracking amount", () => {
+      const tracking = timesheet.plusHoursTracking();
+
+      expect(tracking).toBe(0);
     });
   });
 });


### PR DESCRIPTION
Will resolve #129.

## Background

When getting the working days remaining, we subtract 1 if we've entered hours today and today is a weekday. This is so that if the timesheet is empty for that day, we assume it will be filled with 8 hours. If it's got any time in it, we assume time has been entered and update the tracking to reflect that.

## What's the problem?

When there are 0 weekdays left in the time period, we still perform this check. 

This means that if someone has entered time on the last day of the timesheet, we may return `-1` for the number of days remaining instead of `0`, thus throwing the tracking number off by 8 hours.