### PR TITLE
Disable "prior time" box on the first timesheet of the month

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,10 +25,12 @@ window.summarizeUnanetTimeForReal = (() => {
     const grandTotal = summarizer.timesheet.totalPlusHours() + summarizer.timesheet.totalNonPlusHours();
     const daysWorked = summarizer.timesheet.weekdaysInTimesheet() - summarizer.timesheet.numberOfRemainingWorkDays();
     const trackingPlusPriorPeriod = summarizer.timesheet.plusHoursTracking() + summarizer.priorPeriodAmount;
+    const firstPayPeriod = summarizer.timesheet.timesheetStartDate.date() === 1;
     const theSummary = {
       grandTotalHours: grandTotal,
       hoursByProjectType: summarizer.timesheet.hoursByProjectType(),
       hoursPerWorkday: (grandTotal / daysWorked).toFixed(2),
+      isFirstPayPeriod: firstPayPeriod,
       negativeTracking: trackingPlusPriorPeriod < 0,
       overUnder: (grandTotal - daysWorked * 8).toFixed(2),
       plusHoursInPayPeriod: summarizer.timesheet.expectedPlusHours(),

--- a/src/summary-template.hbs
+++ b/src/summary-template.hbs
@@ -40,7 +40,10 @@
   </thead>
   <tbody>
     <tr class="dataRow">
-      <td><input type="text" id="priorPeriodOverUnder" class="priorPeriodOverUnder" value="{{ priorOverUnderAmount }}">
+      <td><input type="text" id="priorPeriodOverUnder" class="priorPeriodOverUnder" value="{{ priorOverUnderAmount }}"
+          {{#if isFirstPayPeriod}} disabled
+          title="textbox is disabled because hours can only be carried over from the first to the second pay period, not from the prior month."
+          {{/if}}>
       </td>
       {{#each hoursByProjectType}}
       <td>{{ total }}</td>


### PR DESCRIPTION
Since you can't carry over hours from the prior month.

Resolves #189.