### PR TITLE
Revert "Bump moment from 2.24.0 to 2.25.1 in /bookmarklet (#248)"

### DIFF
--- a/bookmarklet/package-lock.json
+++ b/bookmarklet/package-lock.json
@@ -4444,9 +4444,9 @@
       }
     },
     "moment": {
-      "version": "2.25.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.1.tgz",
-      "integrity": "sha512-nRKMf9wDS4Fkyd0C9LXh2FFXinD+iwbJ5p/lh3CHitW9kZbRbJ8hCruiadiIXZVbeAqKZzqcTvHnK3mRhFjb6w=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/bookmarklet/package.json
+++ b/bookmarklet/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
-    "moment": "^2.25.1"
+    "moment": "^2.24.0"
   },
   "resolutions": {
     "**/fsevents": "^1.2.9"


### PR DESCRIPTION
Resolves #251. 

This reverts commit 7d4a058acda3ddc62e6eab74464d1fdf710c2957.

Verified the fix locally.